### PR TITLE
docs: 公开项目文档规范 + hsu-utils 依赖升级（v0.0.27）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,57 @@
-﻿# [Single Router](https://github.com/VitaTsui/single-router#single-router)
+# @hsu-react/single-router
 
-## 前言
+[![npm version](https://img.shields.io/npm/v/@hsu-react/single-router.svg)](https://www.npmjs.com/package/@hsu-react/single-router)
+[![license](https://img.shields.io/npm/l/@hsu-react/single-router.svg)](./LICENSE)
 
-`single-router` 可以在不改变浏览器路由的情况下，以类似路由跳转的方式变更页面
-
-## 参考
-
-- [React Router](https://github.com/remix-run/react-router/tree/main/packages/react-router)
+不改变浏览器 URL 的 React 单页内路由：以类似路由跳转的方式切换页面，API 参考 [React Router](https://github.com/remix-run/react-router) 设计，支持嵌套路由、动态参数、查询参数与路由隔离。
 
 ## 安装
 
-```sh
-npm install --save @hsu-react/single-router
+```bash
+npm install @hsu-react/single-router
 # 或
 yarn add @hsu-react/single-router
 ```
 
-## 组件
+## 快速上手
 
-### `SingleRouter`
-
-```react
+```tsx
 import React from "react";
-import App from "./App";
+import ReactDOM from "react-dom/client";
 import { SingleRouter } from "@hsu-react/single-router";
+import App from "./App";
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
-);
+const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
+
 root.render(
   <React.StrictMode>
-    // showPath 默认为true 控制路由框是否展示 仅在开发环境作用
-    <SingleRouter showPath={true}>
+    {/* showPath 控制开发环境的路径栏是否展示，默认为 true */}
+    <SingleRouter showPath>
       <App />
     </SingleRouter>
   </React.StrictMode>
 );
 ```
 
-> #### 路由隔离（isolate）
+## 组件
 
-默认情况下所有 `SingleRouter` 共享同一份全局路由状态（并持久化到 localStorage）。
-传入 `isolate` 后，该路由树持有**独立的路由状态**，与其他 SingleRouter（含全局实例）互不影响——
-适合在不同页面 / 弹窗内各自嵌一套局部路由：
+### `SingleRouter`
 
-```react
-// 页面 A 与页面 B 的局部路由互不干扰
+路由容器。默认情况下所有 `SingleRouter` 共享同一份全局路由状态（并持久化到 localStorage）。
+
+| 属性 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| isolate | 创建独立路由状态（路由隔离） | `boolean` | `false` |
+| persistKey | isolate 下持久化到 localStorage `single-router:state:<persistKey>`；不传则状态只存在内存，卸载即消失 | `string` | - |
+| initialPath | isolate 下的初始路径 | `string` | `'/'` |
+| showPath | 开发环境路径栏；isolate 实例默认关闭（多实例会互相遮挡） | `boolean` | `!isolate` |
+
+#### 路由隔离（isolate）
+
+传入 `isolate` 后，该路由树持有**独立的路由状态**，与其他 `SingleRouter`（含全局实例）互不影响——适合在不同页面 / 弹窗内各自嵌一套局部路由：
+
+```tsx
+{/* 页面 A 与页面 B 的局部路由互不干扰 */}
 <SingleRouter isolate>
   <PageARoutes />
 </SingleRouter>
@@ -55,30 +61,21 @@ root.render(
 </SingleRouter>
 ```
 
-| 属性 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| isolate | 创建独立路由状态（路由隔离） | `boolean` | `false` |
-| persistKey | isolate 下持久化到 localStorage `single-router:state:<persistKey>`；不传则状态只存在内存，卸载即消失 | `string` | - |
-| initialPath | isolate 下的初始路径 | `string` | `'/'` |
-| showPath | 开发环境路径栏；isolate 实例默认关闭（多实例会互相遮挡） | `boolean` | `!isolate` |
-
 > 注意：`routerHistory`（组件树外导航）只作用于**默认全局实例**，isolate 实例请在组件内用 `useNavigate`。
 
 ### `Route`
 
-> #### 基本使用
+声明一条路由。`path` 需要写**完整路径**；也可以不手写 `Route`，用 [`useRoutes`](#useroutes) 由配置生成。
 
-```react
+```tsx
 import React from "react";
 import { Route } from "@hsu-react/single-router";
 
 const App: React.FC = () => {
   return (
     <div className="App">
-      // 可通过 useRoutes 生成
       <Route path="/path1" element={<AppOne />} />
       <Route path="/path2" element={<AppTwo />} />
-      ...
     </div>
   );
 };
@@ -86,21 +83,17 @@ const App: React.FC = () => {
 export default App;
 ```
 
-> #### 嵌套路由
+嵌套路由：子路由写在子组件内部、原地加载（想到达 `/path1/path1-1` 需先进入 `<AppOne />`）：
 
-```react
+```tsx
 import React from "react";
 import { Route } from "@hsu-react/single-router";
 
 const AppOne: React.FC = () => {
   return (
     <div className="AppOne">
-      // 1. 需要完整路由
-      // 2. 若想跳转 "/path1/path1-1" 需要先进入 <AppOne />
-      // 3. 原地加载 <AppOneOne />
-      // 4. 可通过 useRoutes 生成
+      {/* path 需为完整路径 */}
       <Route path="/path1/path1-1" element={<AppOneOne />} />
-      ...
     </div>
   );
 };
@@ -108,51 +101,11 @@ const AppOne: React.FC = () => {
 export default AppOne;
 ```
 
-## HOOKS
-
-### `useRoutes`
-
-`useRoutes` 可以根据路由树，生成路由
-
-```react
-import { Routes } from "@hsu-react/single-router";
-
-const ROUTERS: Routes = [
-  {
-    path: "/path1",
-    element: <AppOne />,
-  },
-  {
-    path: "/path2",
-    element: <AppTwo />,
-  },
-  {
-    path: "/path3",
-    element: <AppThreeLayout />, // 父级布局，内部用 <Outlet /> 渲染匹配的子路由
-    children: [
-      {
-        index: true, // 相当于 'path: "/path3"'
-        element: <AppThree />,
-      },
-      {
-        // path: "/path3/:id",
-        // 或
-        path: "/:id", // 会自动添加 "/path3"，相当于 "/path3/:id"
-        element: <AppThreeOne />,
-      },
-    ]
-  },
-  ...
-];
-
-export default ROUTERS;
-```
-
 ### `Outlet`
 
-带 `children` 的路由中，父级 `element` 通过 `<Outlet />` 渲染当前匹配的子路由（嵌套布局）：
+带 `children` 的路由配置中，父级 `element` 通过 `<Outlet />` 渲染当前匹配的子路由（嵌套布局），可用 `context` 向子路由透传值：
 
-```react
+```tsx
 import { Outlet, useOutletContext } from "@hsu-react/single-router";
 
 const AppThreeLayout: React.FC = () => {
@@ -175,136 +128,119 @@ const AppThree: React.FC = () => {
 - 支持多级嵌套（children 里再有 children，逐层 `<Outlet />`）
 - 父路径含动态段（如 `/users/:id`）时，父 `element` 与子路由内都可用 `useParams` 取到参数
 
-```react
-import { useRoutes } from "@hsu-react/single-router";
-import ROUTERS from "./Routers";
-...
+## Hooks
+
+### `useRoutes`
+
+根据路由配置树生成路由元素：
+
+```tsx
+import { useRoutes, Routes } from "@hsu-react/single-router";
+
+const ROUTERS: Routes = [
+  {
+    path: "/path1",
+    element: <AppOne />,
+  },
+  {
+    path: "/path2",
+    element: <AppTwo />,
+  },
+  {
+    path: "/path3",
+    element: <AppThreeLayout />, // 父级布局，内部用 <Outlet /> 渲染匹配的子路由
+    children: [
+      {
+        index: true, // 相当于 path: "/path3"
+        element: <AppThree />,
+      },
+      {
+        path: "/:id", // 自动拼接父路径，相当于 "/path3/:id"（也可写完整的 "/path3/:id"）
+        element: <AppThreeOne />,
+      },
+    ],
+  },
+];
 
 const App: React.FC = () => {
-  const Routes = useRoutes(ROUTERS);
+  const routes = useRoutes(ROUTERS);
 
-  return (
-    <div className="App">
-      {Routes}
-    </div>
-  );
+  return <div className="App">{routes}</div>;
 };
 ```
 
 ### `useNavigate`
 
-通过 `useNavigate` 进行路由跳转
+路由跳转：
 
-```react
-import React, { useEffect } from "react";
+```tsx
 import { useNavigate } from "@hsu-react/single-router";
-...
 
-const App: React.FC = () => {
-  ...
+const navigate = useNavigate();
 
-  const navigate = useNavigate();
+// 跳转，并记录进 history
+navigate("/path1");
+// 重置 history 后跳转
+navigate("/path1", { replace: true });
 
-  useEffect(() => {
-    // 跳转
-    // 跳转的路由会被记录在 history 中
-    navigate("/path1");
-    // 将history重置并跳转
-    navigate("/path1", { replace: true });
-
-    // 前进 | 后退
-    // 若超出history的范围，则不会被执行
-    // navigate(1)
-    // navigate(-1)
-    // 会将其后的路由都将从 history 中删除
-    // navigate(1, { replace: true })
-    // navigate(-1 , { replace: true })
-  }, [navigate]);
-
-  ...
-};
-
+// 前进 / 后退（超出 history 范围时不执行）
+navigate(1);
+navigate(-1);
+// 前进 / 后退，并把其后的路由从 history 中删除
+navigate(1, { replace: true });
+navigate(-1, { replace: true });
 ```
 
 ### `useLocation`
 
-使用 `useLocation` 获取当前路由
+获取当前路由状态：
 
-```react
-import React, { useEffect } from "react";
+```tsx
 import { useLocation } from "@hsu-react/single-router";
-...
 
-const App: React.FC = () => {
-  ...
-
-  const location = useLocation();
-
-  useEffect(() => {
-    // {pathname: string, history: string[], index: number}
-    // 初始状态
-    // {pathname: '', history: [], index: -1}
-    console.log(location)
-  }, [location]);
-
-  ...
-};
-
+// { pathname: string, history: string[], index: number }
+// 初始状态为 { pathname: '', history: [], index: -1 }
+const location = useLocation();
 ```
 
 ### `useParams`
 
-使用 `useParams` 获取动态路由参数
+获取动态路由参数（如 `/path3/:id` 中的 `id`）：
 
-```react
-import React, { useEffect } from "react";
+```tsx
 import { useParams } from "@hsu-react/single-router";
-...
 
-const App: React.FC = () => {
-  ...
-
-  // return {id: string | undefined}
-  const { id } = useParams<{ id: string }>();
-
-  useEffect(() => {
-    console.log(id);
-  }, [id]);
-
-  ...
-};
-
+// { id: string | undefined }
+const { id } = useParams<{ id: string }>();
 ```
 
 ### `useSearch`
 
-使用 `useSearch` 获取查询参数参数
+读取与修改查询参数：
 
-```react
-import React, { useEffect } from "react";
+```tsx
 import { useSearch } from "@hsu-react/single-router";
-...
 
-const App: React.FC = () => {
-  ...
+const [{ id }, setSearch] = useSearch<{ id: string }>();
 
-  // return {id: string | undefined}
-  const [{ id }, setSearch] = useSearch<{ id: string }>();
-
-  useEffect(() => {
-    console.log(id);
-
-    // 修改当前路由search, 并新增一条记录
-    setSearch({id: [1]})
-    // 修改当前路由search, 历史路由记录不变
-    setSearch({id: [1]}, { replace: true })
-  }, [id]);
-
-  ...
-};
-
+// 修改当前路由 search，历史记录不变（replace 默认为 true）
+setSearch({ id: [1] });
+// 修改当前路由 search，并在历史中新增一条记录
+setSearch({ id: [1] }, { replace: false });
 ```
+
+## 开发
+
+```bash
+yarn          # 安装依赖
+yarn build    # 构建 es/ + lib/ + dist/
+yarn test     # 运行单元测试
+```
+
+## 贡献
+
+日常开发在 `develop` 分支进行（feature 分支合入 `develop`），`main` 只接受来自 `develop` 的 PR；合入 `main` 后按 `package.json` 版本自动打 tag 并发布 npm。PR 标题遵循 [Conventional Commits](https://www.conventionalcommits.org/)。
 
 ## License
 
-MIT
+[MIT](./LICENSE) © VitaHsu

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsu-react/single-router",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "不改变浏览器 URL 的 React 单页内路由，提供类 React Router 的组件与 Hooks API",
   "keywords": [
     "react",
@@ -80,6 +80,6 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "hsu-utils": "^0.0.9"
+    "hsu-utils": "^0.0.55"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,20 @@
 {
   "name": "@hsu-react/single-router",
   "version": "0.0.26",
-  "description": "single-router",
-  "repository": "git@github.com:VitaTsui/single-router.git",
+  "description": "不改变浏览器 URL 的 React 单页内路由，提供类 React Router 的组件与 Hooks API",
+  "keywords": [
+    "react",
+    "router",
+    "single-page",
+    "in-memory-router",
+    "nested-routes",
+    "hooks"
+  ],
+  "homepage": "https://github.com/VitaTsui/single-router#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VitaTsui/single-router.git"
+  },
   "author": "VitaHsu <vitahsu7@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/__tests__/history.test.ts
+++ b/src/__tests__/history.test.ts
@@ -48,12 +48,12 @@ describe('RouterStore', () => {
     history.push('/a')
     history.push('/b')
     history.push('/c')
-    history.go(-1) // 退到 /b，index=1，/c 仍在 history 里
-    history.push('/d') // 此时 index(1) !== length-1(2)，应截断 /c 并追加 /d
+    history.go(-1) // Back to /b, index=1, /c still in history
+    history.push('/d') // Now index(1) !== length-1(2), so /c should be truncated and /d appended
     expect(store.getState()).toMatchObject({ pathname: '/d', history: ['/a', '/b', '/d'], index: 2 })
   })
 
-  // ─── push 查询参数解析（getSearch）────────────────────────────────────────
+  // ─── push query param parsing (getSearch) ────────────────────────────────
 
   test('push：解析 JSON 类型的查询参数（数字、布尔值）', () => {
     history.push('/page?count=5&flag=true')
@@ -68,13 +68,13 @@ describe('RouterStore', () => {
   })
 
   test('push：忽略畸形查询参数（缺少 key 或 value）', () => {
-    // ?=value 缺 key、?key= 缺 value、?valid=1 正常
+    // ?=value missing key, ?key= missing value, ?valid=1 valid
     history.push('/page?=nokey&empty=&valid=1')
     const { index, search } = store.getState()
     expect(search[index]).toEqual({ valid: 1 })
   })
 
-  // ─── 不可变性 ─────────────────────────────────────────────────────────────
+  // ─── Immutability ─────────────────────────────────────────────────────────
 
   test('state 对象不可直接赋值', () => {
     history.push('/push')
@@ -133,11 +133,11 @@ describe('RouterStore', () => {
     history.push('/a')
     history.push('/b')
     history.push('/c')
-    history.go(-1, { replace: true }) // 退到 /b，同时截断 /c
+    history.go(-1, { replace: true }) // Back to /b, truncating /c at the same time
     expect(store.getState()).toMatchObject({ pathname: '/b', history: ['/a', '/b'], index: 1 })
   })
 
-  // ─── 订阅 ─────────────────────────────────────────────────────────────────
+  // ─── Subscription ─────────────────────────────────────────────────────────
 
   test('subscribe：状态变化时通知，退订后不再通知', () => {
     let count = 0
@@ -149,7 +149,7 @@ describe('RouterStore', () => {
     expect(count).toBe(1)
   })
 
-  // ─── 初始路径 ─────────────────────────────────────────────────────────────
+  // ─── Initial path ─────────────────────────────────────────────────────────
 
   test('initialPath：自定义初始路径', () => {
     const s = new RouterStore({ initialPath: '/home' })

--- a/src/__tests__/isolation.test.tsx
+++ b/src/__tests__/isolation.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test, beforeEach } from '@jest/globals'
 import { render, screen, act } from '@testing-library/react'
 import { SingleRouter, Route, useNavigate, routerHistory, defaultRouterStore } from '../index'
 
-/** 点击后跳转到指定路径的按钮 */
+/** Button that navigates to the given path on click */
 const NavButton: React.FC<{ to: string; label: string }> = ({ to, label }) => {
   const navigate = useNavigate()
   return <button onClick={() => navigate(to)}>{label}</button>
@@ -28,11 +28,11 @@ describe('路由隔离（isolate）', () => {
       </>
     )
 
-    // 初始都未匹配
+    // Neither matches initially
     expect(screen.queryByText('A-detail')).toBeNull()
     expect(screen.queryByText('B-detail')).toBeNull()
 
-    // A 导航后只有 A 渲染，B 不受影响
+    // After A navigates, only A renders; B is unaffected
     act(() => {
       screen.getByText('goA').click()
     })
@@ -50,7 +50,7 @@ describe('路由隔离（isolate）', () => {
     act(() => {
       routerHistory.push('/global')
     })
-    // 全局导航不影响隔离实例
+    // Global navigation does not affect the isolated instance
     expect(screen.queryByText('isolated-view')).toBeNull()
   })
 
@@ -91,14 +91,14 @@ describe('路由隔离（isolate）', () => {
     expect(screen.queryByText('saved-view')).not.toBeNull()
     unmount()
 
-    // 重新挂载同 persistKey 的实例，状态恢复
+    // Remounting an instance with the same persistKey restores the state
     render(
       <SingleRouter isolate persistKey='page-a'>
         <Route path='/saved' element={<div>saved-view-2</div>} />
       </SingleRouter>
     )
     expect(screen.queryByText('saved-view-2')).not.toBeNull()
-    // 且默认全局 key 未被污染
+    // And the default global key is not polluted
     expect(localStorage.getItem('single-router:state:page-a')).not.toBeNull()
   })
 })

--- a/src/_utils/getParams.ts
+++ b/src/_utils/getParams.ts
@@ -1,6 +1,6 @@
 /// <reference types="../typing" />
 
-/** 从 pathname 末尾按 paramKeys 数量提取参数（适用于参数在末尾的扁平路由） */
+/** Extracts params from the end of pathname by the number of paramKeys (for flat routes whose params sit at the end) */
 export default function getParams(location: string, paramKeys: string[]): Params {
   if (paramKeys.length === 0) return {}
 
@@ -14,8 +14,8 @@ export default function getParams(location: string, paramKeys: string[]): Params
 }
 
 /**
- * 按 pattern 的段位置提取参数，支持参数在路径中间的场景。
- * 例：pattern /users/:id/posts + pathname /users/5/posts → { id: '5' }
+ * Extracts params by segment position in the pattern, supporting params in the middle of the path.
+ * e.g. pattern /users/:id/posts + pathname /users/5/posts → { id: '5' }
  */
 export function getParamsByPattern(location: string, pattern: string): Params {
   const patternParts = pattern.split('/').filter(Boolean)

--- a/src/_utils/isNullNode.ts
+++ b/src/_utils/isNullNode.ts
@@ -9,7 +9,7 @@ interface NodeInfo {
   refresh: boolean
 }
 
-/** 段级前缀匹配：避免子串误判（如 /path1 误匹配 /path10） */
+/** Segment-level prefix match: avoids substring false positives (e.g. /path1 wrongly matching /path10) */
 function isSegmentPrefix(location: string, path: string): boolean {
   const locationParts = location.split('/').filter(Boolean)
   const pathParts = path.split('/').filter(Boolean)

--- a/src/_utils/setMatch.ts
+++ b/src/_utils/setMatch.ts
@@ -8,7 +8,7 @@ interface MatchData {
   paramKeys: string[]
 }
 
-/** 纯函数：返回追加当前路由后的 match 快照（已存在则原样返回副本） */
+/** Pure function: returns a match snapshot with the current route appended (returns a plain copy if it already exists) */
 export default function setMatch({ match, path, basicName, paramKeys }: MatchData): Match {
   const _match = deepCopy(match ?? [])
 

--- a/src/components/NestedRoute.tsx
+++ b/src/components/NestedRoute.tsx
@@ -13,24 +13,24 @@ export interface NestedRouteProps {
 }
 
 /**
- * 将路径中的动态段（/:param）去掉，得到用于前缀匹配的静态部分。
- * 例：/users/:id/posts → /users/posts
+ * Strips dynamic segments (/:param) from the path, yielding the static part used for prefix matching.
+ * e.g. /users/:id/posts → /users/posts
  */
 function getStaticPath(path: string): string {
   return path.replace(/(\/):(\w+)/gi, '')
 }
 
 /**
- * 提取路径中所有动态参数的 key。
- * 例：/users/:id/posts/:postId → ['id', 'postId']
+ * Extracts the keys of all dynamic params in the path.
+ * e.g. /users/:id/posts/:postId → ['id', 'postId']
  */
 function getParamKeys(path: string): string[] {
   return (path.match(/:(\w+)/g) || []).map((k) => k.slice(1))
 }
 
 /**
- * 判断 pathname 是否落在 pattern（含参数占位符）的范围内（段级前缀匹配）。
- * exact 为 true 时要求段数完全一致。
+ * Checks whether pathname falls within the scope of pattern (with param placeholders), using segment-level prefix matching.
+ * When exact is true, the segment counts must match exactly.
  */
 function matchPattern(pathname: string, pattern: string, exact: boolean): boolean {
   const patternParts = pattern.split('/').filter(Boolean)
@@ -43,28 +43,28 @@ function matchPattern(pathname: string, pattern: string, exact: boolean): boolea
   return patternParts.every((part, i) => part.startsWith(':') || part === locationParts[i])
 }
 
-/** 按 formatRoutes 的语义拼出子路由完整路径：已含父路径则原样，否则父路径 + 子路径 */
+/** Builds the child route's full path following formatRoutes semantics: kept as-is if it already contains the parent path, otherwise parent path + child path */
 function resolveChildPath(parentPath: string, childPath: string): string {
   if (childPath.includes(parentPath)) return childPath
   return `${parentPath}${childPath.startsWith('/') ? '' : '/'}${childPath}`
 }
 
-/** 叶子路由之下不再有子路由：封住 OutletContext，防止叶子里误用 <Outlet/> 时读到自身造成递归 */
+/** No child routes exist below a leaf route: seal OutletContext so a misused <Outlet/> inside a leaf cannot read itself and recurse */
 const EMPTY_OUTLET = { element: null }
 
 const NestedRoute: React.FC<NestedRouteProps> = ({ path: parentPath, element, routes }) => {
   const { pathname, search, index } = useLocation()
 
-  // 规范化父路径（以 / 开头，保留动态段用于匹配与取参）
+  // Normalize the parent path (leading /, keeping dynamic segments for matching and param extraction)
   const rawParent = useMemo(() => (parentPath.startsWith('/') ? parentPath : `/${parentPath}`), [parentPath])
 
-  // 判断当前 pathname 是否在父路由的范围内
+  // Check whether the current pathname is within the parent route's scope
   const isUnder = useMemo(() => matchPattern(pathname, rawParent, false), [pathname, rawParent])
 
-  // 父路径上的动态参数（提供给父 element 及 index 子路由）
+  // Dynamic params on the parent path (provided to the parent element and index child routes)
   const parentParams = useMemo(() => getParamsByPattern(pathname, rawParent), [pathname, rawParent])
 
-  // 找到匹配的直接子路由，返回对应的渲染元素
+  // Find the matching direct child route and return its render element
   const outletElement = useMemo((): React.ReactElement | null => {
     if (!isUnder) return null
 
@@ -72,7 +72,7 @@ const NestedRoute: React.FC<NestedRouteProps> = ({ path: parentPath, element, ro
     const locationParts = pathname.split('/').filter(Boolean)
 
     for (const child of routes) {
-      // ── index 路由：与父路径段数完全一致 ──────────────────────────────
+      // ── Index route: segment count exactly equals the parent path's ──────
       if (child.index) {
         if (locationParts.length === parentParts.length) {
           return <OutletContext.Provider value={EMPTY_OUTLET}>{child.element ?? null}</OutletContext.Provider>
@@ -84,7 +84,7 @@ const NestedRoute: React.FC<NestedRouteProps> = ({ path: parentPath, element, ro
 
       const childPath = resolveChildPath(rawParent, child.path)
 
-      // ── 含 children 的中间路由：前缀匹配，递归交给 NestedRoute ────────
+      // ── Intermediate route with children: prefix match, recurse into NestedRoute ──
       if (child.children) {
         if (matchPattern(pathname, childPath, false)) {
           return <NestedRoute path={childPath} element={child.element} routes={child.children} />
@@ -92,7 +92,7 @@ const NestedRoute: React.FC<NestedRouteProps> = ({ path: parentPath, element, ro
         continue
       }
 
-      // ── 叶子路由：精确匹配 ──────────────────────────────────────────
+      // ── Leaf route: exact match ─────────────────────────────────────────
       if (matchPattern(pathname, childPath, true)) {
         const params = getParamsByPattern(pathname, childPath)
         return (

--- a/src/components/Outlet.tsx
+++ b/src/components/Outlet.tsx
@@ -2,11 +2,11 @@ import React, { useContext } from 'react'
 import { OutletContext, OutletValueContext } from '../contexts'
 
 interface OutletProps {
-  /** 透传给子路由的上下文值，子路由内通过 useOutletContext() 读取 */
+  /** Context value passed down to child routes, read inside them via useOutletContext() */
   context?: unknown
 }
 
-/** 渲染当前匹配的子路由（配合 useRoutes 的 children 使用） */
+/** Renders the currently matched child route (used with useRoutes children) */
 const Outlet: React.FC<OutletProps> = (props) => {
   const { context } = props
   const { element } = useContext(OutletContext)

--- a/src/components/Route.tsx
+++ b/src/components/Route.tsx
@@ -7,10 +7,16 @@ import isNullNode from '../_utils/isNullNode'
 import setMatch from '../_utils/setMatch'
 
 export interface RouteProps {
+  /** Full route path (supports :param dynamic segments), e.g. '/users/:id' */
   path: string
+  /** Element rendered when the path matches */
   element?: React.ReactElement | null
 }
 
+/**
+ * Declares a route: renders element when the current path matches path, otherwise renders null.
+ * Nested routes are written inside child components and loaded in place; they can also be generated from a config tree via useRoutes.
+ */
 const Route: React.FC<RouteProps> = (props) => {
   const { path, element, paramKeys } = formatRoute(props)
   const store = useContext(RouterContext)

--- a/src/components/SingleRouter.tsx
+++ b/src/components/SingleRouter.tsx
@@ -5,26 +5,30 @@ import PathBar from './_PathBar'
 
 interface RSProps {
   children?: React.ReactNode
-  /** 开发环境是否展示路径栏；isolate 实例默认不展示（多实例会互相遮挡） */
+  /** Whether to show the path bar in development; isolate instances hide it by default (multiple instances would overlap each other) */
   showPath?: boolean
   /**
-   * 路由隔离：为本路由树创建独立的路由状态，
-   * 与其他 SingleRouter（含默认全局实例）互不影响。
+   * Router isolation: creates independent routing state for this route tree,
+   * unaffected by other SingleRouter instances (including the default global one).
    */
   isolate?: boolean
   /**
-   * isolate 下的持久化 key（存储于 localStorage 'single-router:state:<persistKey>'）；
-   * 不传则隔离状态只存在内存中，卸载即消失。
+   * Persistence key when isolate is enabled (stored in localStorage as 'single-router:state:<persistKey>');
+   * if omitted, the isolated state lives only in memory and is lost on unmount.
    */
   persistKey?: string
-  /** isolate 下的初始路径，默认 '/' */
+  /** Initial path when isolate is enabled, defaults to '/' */
   initialPath?: string
 }
 
+/**
+ * Router container. By default all SingleRouter instances share the same global routing state (persisted to localStorage);
+ * with isolate enabled it holds its own routing state, suitable for embedding a local router inside a page / modal.
+ */
 const SingleRouter: React.FC<RSProps> = (props) => {
   const { children, isolate = false, persistKey, initialPath, showPath = !isolate } = props
 
-  // isolate 配置仅在首次挂载时生效，实例生命周期内不切换 store
+  // The isolate config only takes effect on first mount; the store never switches during the instance's lifetime
   const store = useMemo(() => {
     if (!isolate) return defaultRouterStore
 

--- a/src/components/_PathBar/index.tsx
+++ b/src/components/_PathBar/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect } from 'react'
 import { useLocation, useNavigate } from '../..'
 import { RouterContext } from '../../contexts'
 import ReactDOM from 'react-dom'
-import { get_string_width } from 'hsu-utils'
+import { get_string_size } from 'hsu-utils'
 import Icon from './Icon'
 
 const PathBar: React.FC = () => {
@@ -64,7 +64,7 @@ const PathBar: React.FC = () => {
             outline: 'none',
             boxSizing: 'border-box',
             pointerEvents: 'none',
-            width: `${get_string_width(fullPath) * 14 + 40}px`,
+            width: `${get_string_size(fullPath, { size: 14 }).width + 40}px`,
             height: '100%',
             padding: '0 10px',
             fontSize: '14px',

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -3,7 +3,7 @@
 import React, { createContext } from 'react'
 import { RouterStore, defaultRouterStore } from '../history'
 
-/** 当前路由树所属的 store（isolate 时为实例级，否则为全局默认） */
+/** The store the current route tree belongs to (per-instance under isolate, otherwise the global default) */
 export const RouterContext = createContext<RouterStore>(defaultRouterStore)
 
 export const LocationContext = createContext<{ location: IRouter }>({ location: defaultRouterStore.getState() })
@@ -16,8 +16,8 @@ export interface OutletState {
   element: React.ReactElement | null
 }
 
-/** 当前层级待渲染的子路由（由 NestedRoute 提供，Outlet 消费） */
+/** The child route to render at the current level (provided by NestedRoute, consumed by Outlet) */
 export const OutletContext = createContext<OutletState>({ element: null })
 
-/** <Outlet context={...}> 透传给子路由的值（useOutletContext 消费） */
+/** The value <Outlet context={...}> passes down to child routes (consumed by useOutletContext) */
 export const OutletValueContext = createContext<unknown>(undefined)

--- a/src/history/_go.ts
+++ b/src/history/_go.ts
@@ -4,7 +4,7 @@ export interface GoOptions {
   replace?: boolean
 }
 
-/** 纯函数：基于当前状态计算 go 后的新状态；越界时返回原状态 */
+/** Pure function: computes the new state after a go based on the current state; returns the original state when out of bounds */
 export default function go(state: IRouter, delta: number, options?: GoOptions): IRouter {
   const { history, index, search } = state
 

--- a/src/history/_push.ts
+++ b/src/history/_push.ts
@@ -25,7 +25,7 @@ function getSearch(pathname: string) {
   return search
 }
 
-/** 纯函数：基于当前状态计算 push 后的新状态 */
+/** Pure function: computes the new state after a push based on the current state */
 export default function push(state: IRouter, pathname: string, options?: PushOptions): IRouter {
   const _pathname = pathname.split('?')[0]
   const _search = getSearch(pathname)
@@ -34,7 +34,7 @@ export default function push(state: IRouter, pathname: string, options?: PushOpt
 
   if (options?.replace) {
     if (index === -1) {
-      // 空历史，直接写入第一条
+      // Empty history: write the first entry directly
       return {
         index: 0,
         pathname: _pathname,
@@ -55,7 +55,7 @@ export default function push(state: IRouter, pathname: string, options?: PushOpt
     }
   }
 
-  // 如果目标路径已存在于历史中，回退到该位置并截断后续历史
+  // If the target path already exists in history, go back to that position and truncate the entries after it
   const existingIndex = history.indexOf(_pathname)
   if (existingIndex !== -1) {
     return {
@@ -66,7 +66,7 @@ export default function push(state: IRouter, pathname: string, options?: PushOpt
     }
   }
 
-  // 常规 push：若不在末尾则截断后续再追加，否则直接追加
+  // Regular push: if not at the end, truncate later entries before appending; otherwise append directly
   const shouldTruncate = index !== history.length - 1 && index >= 0
   const newHistory = shouldTruncate ? history.slice(0, index + 1) : [...history]
   const newSearch = shouldTruncate ? search.slice(0, index + 1) : [...search]

--- a/src/history/index.ts
+++ b/src/history/index.ts
@@ -3,15 +3,16 @@
 import go, { GoOptions } from './_go'
 import push, { PushOptions } from './_push'
 
+/** Navigator: go moves forward / backward, push navigates to a given path */
 export interface Navigator {
   go(delta: number, options?: GoOptions): void
   push(to: string, options?: PushOptions): void
 }
 
 export interface RouterStoreOptions {
-  /** 持久化到 localStorage 的 key；不传则路由状态只存在内存中 */
+  /** localStorage key for persistence; if omitted, routing state lives only in memory */
   persistKey?: string
-  /** 初始路径，默认 '/' */
+  /** Initial path, defaults to '/' */
   initialPath?: string
 }
 
@@ -30,8 +31,8 @@ function readPersisted(persistKey: string): IRouter | null {
 }
 
 /**
- * 路由状态容器：每个实例持有独立的 pathname/history/search/match/refreshing，
- * 互不影响（路由隔离的基础）。通过 subscribe 订阅变更。
+ * Routing state container: each instance holds its own pathname/history/search/match/refreshing,
+ * independent of the others (the basis of router isolation). Subscribe to changes via subscribe.
  */
 export class RouterStore {
   private _state: IRouter
@@ -70,14 +71,14 @@ export class RouterStore {
     if (state === this._state) return
 
     this._state = Object.freeze(state) as IRouter
-    // 路由变化后重新收集 match（Route 挂载时重建）
+    // Re-collect match after a route change (rebuilt when Route components mount)
     this._match = []
 
     if (this._persistKey) {
       try {
         localStorage.setItem(this._persistKey, JSON.stringify(state))
       } catch {
-        // 持久化失败不影响路由本身
+        // Persistence failures do not affect routing itself
       }
     }
 
@@ -90,7 +91,7 @@ export class RouterStore {
     this._match = match
   }
 
-  /** 刷新当前路由：已匹配的 Route 卸载 300ms 后重新挂载，模拟页面刷新 */
+  /** Reload the current route: matched Routes unmount and remount after 300ms, simulating a page refresh */
   reload = () => {
     this._refreshing = true
     this._emit()
@@ -114,10 +115,10 @@ export class RouterStore {
 }
 
 /**
- * 默认全局 store：不带 isolate 的 <SingleRouter> 共享它，
- * 并沿用 localStorage 持久化（与历史版本行为一致）。
+ * Default global store: shared by all <SingleRouter> instances without isolate,
+ * with routing state persisted to localStorage.
  */
 export const defaultRouterStore = new RouterStore({ persistKey: DEFAULT_STORAGE_KEY })
 
-/** 组件树外导航（如 store 中跳转）：作用于默认全局 store */
+/** Navigation outside the component tree (e.g. from a store): operates on the default global store */
 export const routerHistory: Navigator = defaultRouterStore.navigator

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -1,6 +1,10 @@
 import { useContext } from 'react'
 import { LocationContext } from '../contexts'
 
+/**
+ * Returns the current routing state `{ pathname, history, index, search }`;
+ * the initial state is `{ pathname: '', history: [], index: -1 }`.
+ */
 export default function useLocation(): IRouter {
   const location = useContext(LocationContext).location
 

--- a/src/hooks/useNavigate.ts
+++ b/src/hooks/useNavigate.ts
@@ -7,6 +7,12 @@ interface NavigateFunction {
   (to: string | number, options?: PushOptions | GoOptions): void
 }
 
+/**
+ * Returns the navigate function.
+ * - `navigate('/path')` navigates and records the entry in history; `{ replace: true }` resets history before navigating
+ * - `navigate(1)` / `navigate(-1)` moves forward / backward (no-op when out of history bounds);
+ *   with `{ replace: true }`, the routes after the target are removed from history
+ */
 export default function useNavigate(): NavigateFunction {
   const { navigator } = useContext(RouterContext)
 

--- a/src/hooks/useOutletContext.ts
+++ b/src/hooks/useOutletContext.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { OutletValueContext } from '../contexts'
 
-/** 读取最近一层 <Outlet context={...}> 透传的值 */
+/** Reads the value passed down by the nearest <Outlet context={...}> */
 export default function useOutletContext<T = unknown>(): T {
   return useContext(OutletValueContext) as T
 }

--- a/src/hooks/useParams.ts
+++ b/src/hooks/useParams.ts
@@ -1,6 +1,10 @@
 import { useContext } from 'react'
 import { ParamsContext } from '../contexts'
 
+/**
+ * Returns the current route's dynamic params (e.g. id in '/users/:id').
+ * The generic T describes the expected param shape; unmatched fields are undefined.
+ */
 export default function useParams<T extends Partial<T>>(): Params | T {
   const params = useContext(ParamsContext).params
 

--- a/src/hooks/useRoutes.tsx
+++ b/src/hooks/useRoutes.tsx
@@ -4,26 +4,37 @@ import NestedRoute from '../components/NestedRoute'
 import formatRoutes from '../_utils/formatRoutes'
 
 export interface PathRoutes {
+  /** Route path; child routes may use a relative segment (e.g. '/:id', auto-joined with the parent path) or a full path */
   path: string
+  /** Whether this is the parent path's default child route */
   index?: true
+  /** Element rendered on match; with children it is usually a layout component that renders child routes via <Outlet /> */
   element?: React.ReactElement | null
+  /** Nested child routes */
   children?: Routes
 }
 
 export interface IndexRoutes {
+  /** Default child route: its path equals the parent path */
   index: true
   path?: string
   element?: React.ReactElement | null
   children?: Routes
 }
 
+/** Route config tree consumed by useRoutes to generate route elements */
 export type Routes = Array<PathRoutes | IndexRoutes>
 
+/**
+ * Generates route elements from a route config tree.
+ * Nodes with children go through NestedRoute (supports <Outlet /> nested layouts);
+ * the rest are expanded directly into <Route />.
+ */
 export default function useRoutes(routes: Routes) {
   return (
     <>
       {routes.map((route, i) => {
-        // 有 children 的路由：走 NestedRoute，支持 Outlet
+        // Routes with children: go through NestedRoute, which supports Outlet
         if (route.children) {
           const path = (route as PathRoutes).path ?? ''
           return (
@@ -36,7 +47,7 @@ export default function useRoutes(routes: Routes) {
           )
         }
 
-        // 无 children 的路由：保持原有 flat 渲染逻辑
+        // Routes without children: expand directly into <Route />
         const flat = formatRoutes([route])
         return flat.map((r, j) => <Route key={`${i}-${j}`} {...r} />)
       })}

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -5,6 +5,11 @@ interface SetSearchOptions {
   replace?: boolean
 }
 
+/**
+ * Reads and updates the current route's query params.
+ * `setSearch` defaults to `replace: true` (only updates the current entry's search, history stays unchanged);
+ * pass `{ replace: false }` to append a new entry to history instead.
+ */
 export default function useSearch<T extends Partial<T>>(): [T, (search: T, options?: SetSearchOptions) => void] {
   const store = useContext(RouterContext)
   const search = useContext(SearchContext).search as T

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,6 +1752,11 @@ data-urls@^4.0.0:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^12.0.0"
 
+dayjs@^1.11.19:
+  version "1.11.21"
+  resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
+
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -2528,10 +2533,13 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hsu-utils@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/hsu-utils/-/hsu-utils-0.0.9.tgz#1aafc993cc9dd9c281a20bac52a1bb551ac7581f"
-  integrity sha512-0AktOlL83aNsoXKA6/P353Ez/dgeKXSUgTK4POO1m5KQO4vLRyvQ/hpF3+R+bxo0bITxlJuvNe+16urjqzuy9g==
+hsu-utils@^0.0.55:
+  version "0.0.55"
+  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.55.tgz#0a8302452563f6b617d99c95c5a06afc5cfed936"
+  integrity sha512-63+7kY1CwbIaLKurqhTzu+7fPygqIz9AquJ6ofss663YOC6MkLYyQwqZrXBWmaK5ojBuq09ZYjH/dungrbXVAA==
+  dependencies:
+    dayjs "^1.11.19"
+    pdfjs-dist "2.13.216"
 
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"
@@ -3777,6 +3785,13 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pdfjs-dist@2.13.216:
+  version "2.13.216"
+  resolved "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.13.216.tgz#251a11c9c8c6db19baacd833a4e6986c517d1ab3"
+  integrity sha512-qn/9a/3IHIKZarTK6ajeeFXBkG15Lg1Fx99PxU09PAU2i874X8mTcHJYyDJxu7WDfNhV6hM7bRQBZU384anoqQ==
+  dependencies:
+    web-streams-polyfill "^3.2.0"
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -4194,7 +4209,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4253,7 +4277,14 @@ string.prototype.trimstart@^1.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4582,6 +4613,11 @@ watchpack@^2.4.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+web-streams-polyfill@^3.2.0:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
@@ -4720,7 +4756,16 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## 内容

- **docs**: README 统一结构（徽章/快速上手/组件/Hooks/贡献/License），修正 useSearch 示例中 replace 默认值描述；导出组件/Hooks/类型补英文 JSDoc，注释统一英文
- **chore**: hsu-utils 升级 ^0.0.9 → ^0.0.55；_PathBar 迁移已移除的 get_string_width → get_string_size（像素级测量，语义等价）；版本 0.0.27

## 验证

- 32 个单测全过，`yarn build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)